### PR TITLE
RDKINCDT-21871: Fix nss package dependency

### DIFF
--- a/recipes-images/rdk-fullstack-image.bb
+++ b/recipes-images/rdk-fullstack-image.bb
@@ -5,6 +5,8 @@ FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
 
 IMAGE_LINGUAS = " "
 
+DEPENDS += "nss-native"
+
 IMAGE_INSTALL = " \
                  packagegroup-vendor-layer \
                  packagegroup-middleware-layer \


### PR DESCRIPTION
Reason for change: It seems that the networkmanager is being enabled for the first time in release 1.17.0. This module has a dependency on nss, which in turn depends on nss-native to support its ipk postinstall script. However, since the image assembler does not have a direct dependency on networkmanager and its ipks are being installed via the middleware packagegroup (packagegroup-middleware-layer), the nss-native is not being built and the necessary utility (shlibsign) is not made available for the do_rootfs task.