### PR TITLE
RDKINCDT-21871: Revert - Fix nss package dependency

### DIFF
--- a/recipes-images/rdk-fullstack-image.bb
+++ b/recipes-images/rdk-fullstack-image.bb
@@ -5,8 +5,6 @@ FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
 
 IMAGE_LINGUAS = " "
 
-DEPENDS += "nss-native"
-
 IMAGE_INSTALL = " \
                  packagegroup-vendor-layer \
                  packagegroup-middleware-layer \


### PR DESCRIPTION
This reverts commit cb79eaaf6b9c853473ea09d03a1dae2c8a312454.

This fix has been moved to meta-image-assembler [PR - https://github.com/rdkcentral/meta-image-assembler/pull/4/files ] 
Hence reverting from this repo