### PR TITLE
RDKEMW-6124 : RDK-E : MW specific oss feed for element

### DIFF
--- a/conf/template/bblayers.conf.sample
+++ b/conf/template/bblayers.conf.sample
@@ -21,7 +21,7 @@ BBLAYERS ?= " \
   "
 
 BBLAYERS =+ "${@'${MANIFEST_PATH_COMMON_OSS_REFERENCE}' if os.path.isfile('${MANIFEST_PATH_COMMON_OSS_REFERENCE}/conf/layer.conf') else ''}"
-BBLAYERS =+ "${@'${MANIFEST_PATH_OSS_RELEASE}' if os.path.isfile('${MANIFEST_PATH_OSS_RELEASE}/conf/layer.conf') else ''}"
+BBLAYERS =+ "${@d.getVar('MANIFEST_PATH_OSS_RELEASE') if d.getVar('MANIFEST_PATH_OSS_RELEASE') is not None and os.path.isfile(d.getVar('MANIFEST_PATH_OSS_RELEASE') + '/conf/layer.conf') else ''}"
 
 BBLAYERS =+ "${@'${MANIFEST_PATH_RDK_TOOLS}' if os.path.isfile('${MANIFEST_PATH_RDK_TOOLS}/conf/layer.conf') else ''}"
 BBLAYERS =+ "${@'${MANIFEST_PATH_RDK_IMAGES}' if os.path.isfile('${MANIFEST_PATH_RDK_IMAGES}/conf/layer.conf') else ''}"


### PR DESCRIPTION
Reason for change:
	 disable oss-reference-release feed

Test Procedure: None
Risks: Low

Signed-off-by:Anooj Cheriyan <Anooj_Cheriyan@comcast.com>