### PR TITLE
RDKOSS-493: Enable SKIP_RECIPE_IPK_PKGS in IA builds

### DIFF
--- a/recipes-images/rdk-fullstack-image.bb
+++ b/recipes-images/rdk-fullstack-image.bb
@@ -54,3 +54,4 @@ dobby_generic_config_patch(){
 wpeframework_binding_patch(){
     sed -i "s/127.0.0.1/0.0.0.0/g" ${IMAGE_ROOTFS}/etc/WPEFramework/config.json
 }
+SKIP_RECIPE_IPK_PKGS ="1"


### PR DESCRIPTION
Reason for change:
The variable OSS_IPK_MODE, previously used to control IPK package behavior, was defined in the base-deps-resolver.bbclass file within the meta-stack-layering-support layer. This variable was valid only up to tag 2.1.4. Starting from tag 3.0.0, it has been replaced by SKIP_RECIPE_IPK_PKGS in the same file.

To validate the new behavior, SKIP_RECIPE_IPK_PKGS was enabled in local.conf and a build was initiated for RTK-XIONE. The build confirmed that the specified IPK packages were fetched from Artifactory, replicating the functionality of OSS_IPK_MODE.

Test Procedure:
Added `SKIP_RECIPE_IPK_PKGS = "1"` in rdk-fullstack-image.bb.