### PR TITLE
RDKE-1029: Remove Thunder UI from PROD RDKE images

### DIFF
--- a/recipes-images/rdk-fullstack-image.bb
+++ b/recipes-images/rdk-fullstack-image.bb
@@ -20,7 +20,7 @@ IMAGE_INSTALL:remove = "linux-meson"
 inherit core-image custom-rootfs-creation
 
 IMAGE_ROOTFS_SIZE ?= "8192"
-IMAGE_ROOTFS_EXTRA_SPACE:append = "${@bb.utils.contains("DISTRO_FEATURES", "systemd", " + 4096", "" ,d)}"
+IMAGE_ROOTFS_EXTRA_SPACE:append = "${@bb.utils.contains('DISTRO_FEATURES', 'debug-variant', 'wpeframework_binding_patch; ', '', d)}"
 
 ROOTFS_POSTPROCESS_COMMAND += "dobby_generic_config_patch; "
 ROOTFS_POSTPROCESS_COMMAND += "create_NM_link; "


### PR DESCRIPTION
Reason for change: restrict port 9998 access to dev images
Test Procedure: see Jira ticket
Risks: None
Priority: P0

Signed-off-by:AkshayKumar_Gampa AkshayKumar_Gampa@comcast.com