### PR TITLE
RDKE-1029: Remove Thunder UI from PROD RDKE images

### DIFF
--- a/recipes-images/rdk-fullstack-image.bb
+++ b/recipes-images/rdk-fullstack-image.bb
@@ -25,7 +25,7 @@ IMAGE_ROOTFS_EXTRA_SPACE:append = "${@bb.utils.contains("DISTRO_FEATURES", "syst
 ROOTFS_POSTPROCESS_COMMAND += "dobby_generic_config_patch; "
 ROOTFS_POSTPROCESS_COMMAND += "create_NM_link; "
 ROOTFS_POSTPROCESS_COMMAND += "create_init_link; "
-ROOTFS_POSTPROCESS_COMMAND += "wpeframework_binding_patch; "
+ROOTFS_POSTPROCESS_COMMAND += "${@bb.utils.contains('DISTRO_FEATURES', 'debug-variant', 'wpeframework_binding_patch; ', '', d)}"
 
 create_init_link() {
         ln -sf /sbin/init ${IMAGE_ROOTFS}/init


### PR DESCRIPTION
Reason for change: restrict port 9998 access to dev images
Test Procedure: see Jira ticket
Risks: None
Priority: P0

Signed-off-by:AkshayKumar_Gampa AkshayKumar_Gampa@comcast.com