### PR TITLE
RDK-55604: Include meta-lts-mixins and meta-clang layers

### DIFF
--- a/conf/template/bblayers.conf.sample
+++ b/conf/template/bblayers.conf.sample
@@ -57,6 +57,8 @@ BBLAYERS =+ "${@d.getVar('MANIFEST_PATH_RDK_RESTRICTED') if d.getVar('MW_LAYER_B
 BBLAYERS =+ "${@d.getVar('MANIFEST_PATH_RDK_VIDEO') if d.getVar('MW_LAYER_BUILD_TYPE') == 'MW_DEV' and d.getVar('MANIFEST_PATH_RDK_VIDEO') is not None and  os.path.isfile(d.getVar('MANIFEST_PATH_RDK_VIDEO') + '/conf/layer.conf')  else ''}"
 BBLAYERS =+ "${@d.getVar('MANIFEST_PATH_META_PYTHON2') if d.getVar('MW_LAYER_BUILD_TYPE') == 'MW_DEV' and d.getVar('MANIFEST_PATH_META_PYTHON2') is not None and  os.path.isfile(d.getVar('MANIFEST_PATH_META_PYTHON2') + '/conf/layer.conf')  else ''}"
 BBLAYERS =+ "${@d.getVar('MANIFEST_PATH_RDK_SKY') if d.getVar('MW_LAYER_BUILD_TYPE') == 'MW_DEV' and d.getVar('MANIFEST_PATH_RDK_SKY') is not None and  os.path.isfile(d.getVar('MANIFEST_PATH_RDK_SKY') + '/conf/layer.conf')  else ''}"
+BBLAYERS =+ "${@d.getVar('MANIFEST_PATH_META_MIXIN') if d.getVar('MW_LAYER_BUILD_TYPE') == 'MW_DEV' and d.getVar('MANIFEST_PATH_META_MIXIN') is not None and  os.path.isfile(d.getVar('MANIFEST_PATH_META_MIXIN') + '/conf/layer.conf')  else ''}"
+BBLAYERS =+ "${@d.getVar('MANIFEST_PATH_META_CLANG') if d.getVar('MW_LAYER_BUILD_TYPE') == 'MW_DEV' and d.getVar('MANIFEST_PATH_META_CLANG') is not None and  os.path.isfile(d.getVar('MANIFEST_PATH_META_CLANG') + '/conf/layer.conf')  else ''}"
 
 # Middleware layers: restricted/proprietary
 BBLAYERS =+ " \


### PR DESCRIPTION
These layers are required to build Rust code in secclient in support of RDK-55604.